### PR TITLE
Avoid leaking anchor elements for URL calculations

### DIFF
--- a/dist/hawtio-core-navigation.js
+++ b/dist/hawtio-core-navigation.js
@@ -635,14 +635,15 @@ var HawtioMainNav;
     return false;
   }
 
+  // Construct once and share between invocations to avoid memory leaks
+  var tmpLink = $('<a>');
   function addIsSelected($location, item) {
     if (!('isSelected' in item) && 'href' in item) {
       item.isSelected = function() {
         // item.href() might be relative, in which
         // case we should let the browser resolve
         // what the full path should be
-        var tmpLink = $('<a>')
-          .attr("href", item.href());
+        tmpLink.attr("href", item.href());
         var href = new URI(tmpLink[0].href);
         var itemPath = trimLeading(href.path(), '/');
 

--- a/hawtio-core-navigation.js
+++ b/hawtio-core-navigation.js
@@ -635,14 +635,15 @@ var HawtioMainNav;
     return false;
   }
 
+  // Construct once and share between invocations to avoid memory leaks
+  var tmpLink = $('<a>');
   function addIsSelected($location, item) {
     if (!('isSelected' in item) && 'href' in item) {
       item.isSelected = function() {
         // item.href() might be relative, in which
         // case we should let the browser resolve
         // what the full path should be
-        var tmpLink = $('<a>')
-          .attr("href", item.href());
+        tmpLink.attr("href", item.href());
         var href = new URI(tmpLink[0].href);
         var itemPath = trimLeading(href.path(), '/');
 


### PR DESCRIPTION
We're seeing enormous numbers of calls to `item.isSelected` and `item.itemIsValid` on every navigate (50-100 calls to each of those functions for each navigation click in the sample index.html). The `isSelected` call is constructing a new anchor element on every invocation to do relative URL checking.

@spadgett tracked this down as the source of a memory leak in https://github.com/openshift/origin/issues/1921#issuecomment-108141275

This PR reuses the anchor element which cut the number of leaked anchors to almost 0 (down from tens of thousands after navigating around for a while).
