### PR TITLE
Fix fatal exception during click() processing after partial module reload

### DIFF
--- a/hawtio-core-navigation.js
+++ b/hawtio-core-navigation.js
@@ -40,7 +40,7 @@ var HawtioMainNav;
   HawtioMainNav.pluginName = 'hawtio-nav';
   var log = Logger.get(HawtioMainNav.pluginName);
 
-  // Actions class with some pre-defined actions 
+  // Actions class with some pre-defined actions
   var Actions = (function() {
     function Actions() {}
     Object.defineProperty(Actions, "ADD", {
@@ -618,7 +618,9 @@ var HawtioMainNav;
       item.click = function($event) {
         if (!($event instanceof jQuery.Event)) {
           try {
-            $rootScope.$apply();
+            if(!$rootScope.$$phase) {
+              $rootScope.$apply();
+            }
           } catch (e) {
             // ignore
           }


### PR DESCRIPTION
For some reason, event handlers are propagating to hawtio-core-navigation "click" 
handler during $rootScope.$apply, and thus a forever-loop occurs with $rootScope.$apply(), which requires a complete page refresh.  This happens frequently with my app since it uses jspm/systemjs with a hot module reloader, and the culprit is here when the user clicks any of the hawtio tabs
rendered after one of the views refreshes under the covers.

This fix simply protects $rootScope.$apply with check against $$phase to avoid double-apply
(ie. dreaded "already in progress" exception).
