### PR TITLE
Fix #15 - error on IE11

### DIFF
--- a/dist/hawtio-core-navigation.js
+++ b/dist/hawtio-core-navigation.js
@@ -5,8 +5,9 @@
 /*globals window document Logger CustomEvent URI _ $ angular hawtioPluginLoader jQuery*/
 
 // Polyfill custom event if necessary since we kinda need it
+// https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
 (function () {
-  if (!window.CustomEvent) {
+  if (typeof window.CustomEvent !== "function") {
     function CustomEvent ( event, params ) {
       params = params || { bubbles: false, cancelable: false, detail: undefined };
       var evt = document.createEvent( 'CustomEvent' );
@@ -1004,8 +1005,8 @@ var HawtioMainNav;
 
 
 
-angular.module("hawtio-nav").run(["$templateCache", function($templateCache) {$templateCache.put("templates/main-nav/layoutFull.html","<div ng-view></div>\n\n\n");
-$templateCache.put("templates/main-nav/layoutTest.html","<div>\n  <h1>Test Layout</h1>\n  <div ng-view>\n\n\n  </div>\n</div>\n\n\n");
-$templateCache.put("templates/main-nav/navItem.html","<li ng-class=\"{ active: item.isSelected() }\" ng-hide=\"item.hide()\">\n  <a ng-href=\"{{item.href()}}\" ng-click=\"item.click($event)\" ng-bind-html=\"item.title()\" title=\"{{item.tooltip()}}\"></a>\n</li>\n");
-$templateCache.put("templates/main-nav/subTabHeader.html","<li class=\"header\">\n  <a href=\"\"><strong>{{item.title()}}</strong></a>\n</li>\n");
-$templateCache.put("templates/main-nav/welcome.html","<div ng-controller=\"HawtioNav.WelcomeController\"></div>\n");}]);
+angular.module("hawtio-nav").run(["$templateCache", function($templateCache) {$templateCache.put("templates/main-nav/layoutFull.html","<div ng-view></div>\r\n\r\n\r\n");
+$templateCache.put("templates/main-nav/layoutTest.html","<div>\r\n  <h1>Test Layout</h1>\r\n  <div ng-view>\r\n\r\n\r\n  </div>\r\n</div>\r\n\r\n\r\n");
+$templateCache.put("templates/main-nav/navItem.html","<li ng-class=\"{ active: item.isSelected() }\" ng-hide=\"item.hide()\">\r\n  <a ng-href=\"{{item.href()}}\" ng-click=\"item.click($event)\" ng-bind-html=\"item.title()\" title=\"{{item.tooltip()}}\"></a>\r\n</li>\r\n");
+$templateCache.put("templates/main-nav/subTabHeader.html","<li class=\"header\">\r\n  <a href=\"\"><strong>{{item.title()}}</strong></a>\r\n</li>\r\n");
+$templateCache.put("templates/main-nav/welcome.html","<div ng-controller=\"HawtioNav.WelcomeController\"></div>\r\n");}]);

--- a/dist/hawtio-nav-example.js
+++ b/dist/hawtio-nav-example.js
@@ -139,6 +139,6 @@ var Test;
     hawtioPluginLoader.addModule(Test.pluginName);
 })(Test || (Test = {}));
 
-angular.module("test").run(["$templateCache", function($templateCache) {$templateCache.put("test/html/page1.html","<div class=\"row\">\n  <div class=\"col-md-12\">\n    <h1>Page 1</h1>\n    <p>foo</p>\n  </div>\n</div>\n");
-$templateCache.put("test/html/page2.html","<div class=\"row\">\n  <div class=\"col-md-12\">\n    <h1>Page 2</h1>\n  </div>\n</div>\n");
-$templateCache.put("test/html/page3.html","<div class=\"row\">\n  <div class=\"col-md-12\">\n    <h1>Page 3</h1>\n  </div>\n</div>\n");}]);
+angular.module("test").run(["$templateCache", function($templateCache) {$templateCache.put("test/html/page1.html","<div class=\"row\">\r\n  <div class=\"col-md-12\">\r\n    <h1>Page 1</h1>\r\n    <p>foo</p>\r\n  </div>\r\n</div>\r\n");
+$templateCache.put("test/html/page2.html","<div class=\"row\">\r\n  <div class=\"col-md-12\">\r\n    <h1>Page 2</h1>\r\n  </div>\r\n</div>\r\n");
+$templateCache.put("test/html/page3.html","<div class=\"row\">\r\n  <div class=\"col-md-12\">\r\n    <h1>Page 3</h1>\r\n  </div>\r\n</div>\r\n");}]);

--- a/hawtio-core-navigation.js
+++ b/hawtio-core-navigation.js
@@ -5,8 +5,9 @@
 /*globals window document Logger CustomEvent URI _ $ angular hawtioPluginLoader jQuery*/
 
 // Polyfill custom event if necessary since we kinda need it
+// https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
 (function () {
-  if (!window.CustomEvent) {
+  if (typeof window.CustomEvent !== "function") {
     function CustomEvent ( event, params ) {
       params = params || { bubbles: false, cancelable: false, detail: undefined };
       var evt = document.createEvent( 'CustomEvent' );

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <script src="libs/angular/angular.js"></script>
     <script src="libs/angular-sanitize/angular-sanitize.js"></script>
     <script src="libs/js-logger/src/logger.js"></script>
-    <script src="libs/hawtio-core/hawtio-core.js"></script>
+    <script src="libs/hawtio-core/dist/hawtio-core.js"></script>
     <script src="libs/lodash/lodash.js"></script>
     <script src="libs/angular-route/angular-route.js"></script>
     <script src="libs/urijs/src/URI.js"></script>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = function(config) {
       'libs/angular/angular.js',
       'libs/angular-sanitize/angular-sanitize.js',
       'libs/js-logger/src/logger.js',
-      'libs/hawtio-core/hawtio-core.js',
+      'libs/hawtio-core/dist/hawtio-core.js',
       'libs/lodash/lodash.js',
       'libs/angular-route/angular-route.js',
       'libs/urijs/src/URI.js',


### PR DESCRIPTION
The problem is that the polyfill for custom events isn't running on IE11 due to an incorrect browser support verification. From MDN docs: "Internet Explorer >= 9 adds a CustomEvent object to the window, but with correct implementations, this is a function." I've also fixed the references to 'hawtio-core.js' in index.html and karma.conf.js.
